### PR TITLE
Fix the package release stage by using a generic container

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,8 +49,8 @@ pipeline {
           sh "docker push openstax/cnx-archive:${release}"
           sh "docker push openstax/cnx-archive:latest"
         }
-        // Note, '.git' is a volume, because versioneer needs it to resolve the python distribution's version. 
-        sh "docker run --rm -e TWINE_USERNAME -e TWINE_PASSWORD -v ${WORKSPACE}/.git:/src/.git:ro openstax/cnx-archive:latest /bin/bash -c \"pip install -q twine && python2 setup.py bdist_wheel && twine upload dist/*\""
+        // Release the Python package to the package index
+        sh "docker run --rm -e TWINE_USERNAME -e TWINE_PASSWORD --volume ${WORKSPACE}:/usr/src/:rw --workdir /usr/src/ python:2.7 /bin/bash -c \"pip install -q twine && python2 setup.py bdist_wheel && twine upload dist/*\""
       }
     }
   }


### PR DESCRIPTION
Changing the Dockerfile to run the container as an unprivilaged user
has made the existing release stage command fail due to permissions errors
while installing twine. To keep it a single line command, I'm simply
switching to use the base `python:2.7` container. The results will be the same
because the `MANIFEST.in` dictates what goes in a package,
not the container's contents.