### PR TITLE
Add meta noindex tag to archive html pages

### DIFF
--- a/cnxarchive/views/content.py
+++ b/cnxarchive/views/content.py
@@ -158,6 +158,15 @@ def get_content_html(request):
     else:
         content = result['content']
 
+    if '<head>' in content:
+        content = content.replace(
+            '</head>',
+            '<meta name="robots" content="noindex"/></head>', 1)
+    else:
+        content = content.replace(
+            '<body',
+            '<head><meta name="robots" content="noindex"/></head><body', 1)
+
     resp = request.response
     resp.body = content
     resp.status = "200 OK"


### PR DESCRIPTION
We want to make google ignore archive in search results.

According to https://support.google.com/webmasters/answer/93710?hl=en we
just need to add:

```
<meta name="robots" content="noindex">
```

to prevent most search engine web crawlers from indexing a page.  Since
we have xhtml, I just made it a self closing tag.

For openstax/cnx#480