### PR TITLE
Fix xpath.html template error when title isn't ascii

### DIFF
--- a/cnxarchive/tests/test_functional.py
+++ b/cnxarchive/tests/test_functional.py
@@ -437,3 +437,27 @@ class SlugTestCase(testing.FunctionalTestCase):
         for ext in self.contents_extensions:
             self.testapp.get('/contents/{}@8/{}{}'.format(short_id, slug, ext),
                              status=404)
+
+
+class XPathTestCase(testing.FunctionalTestCase):
+    fixture = testing.data_fixture
+
+    def setUp(self):
+        self.fixture.setUp()
+
+    def tearDown(self):
+        self.fixture.tearDown()
+
+    def test_xpath_utf8(self):
+        resp = self.testapp.get(
+            '/xpath.json?id=kctfKCuK@1&q=//h:p[@id="para1"]&type=html')
+        self.assertEqual(resp.status, '200 OK')
+        self.assertEqual(resp.json[0]["title"], u"Indkøb")
+
+        resp = self.testapp.get(
+            '/xpath.html?id=kctfKCuK@1&q=//h:p[@id="para1"]&type=html')
+        self.assertEqual(resp.status, '200 OK')
+        self.assertIn(
+            '<a href="/contents/91cb5f28-2b8a-4324-9373-dac1d617bc24@1">'
+            'Indkøb</a>',
+            resp.body)

--- a/cnxarchive/views/xpath.py
+++ b/cnxarchive/views/xpath.py
@@ -250,6 +250,7 @@ class XPathView(object):
                 'content',
                 ident_hash=docs_map[ident]['ident_hash'],
             )
+            docs_map[ident]['title'] = docs_map[ident]['title'].decode('utf-8')
             del docs_map[ident]['module_ident']
 
         return list([x for x in docs_map.values() if 'matches' in x])


### PR DESCRIPTION
The traceback from archive when searching for self closing tags using
xpath.html:

https://archive-staging.cnx.org/xpath.html?id=7fccc9cf-9b71-44f6-800b-f9457fd64335@8.1&q=//*[not(node())]&type=html

```
2019-07-24 08:49:58,049 ERROR [waitress][waitress] Exception while serving /xpath.html
Traceback (most recent call last):
  File "/var/cnx/venvs/archive/local/lib/python2.7/site-packages/waitress/channel.py", line 356, in service
    task.service()
  File "/var/cnx/venvs/archive/local/lib/python2.7/site-packages/waitress/task.py", line 176, in service
    self.execute()
  File "/var/cnx/venvs/archive/local/lib/python2.7/site-packages/waitress/task.py", line 447, in execute
    app_iter = self.channel.server.application(env, start_response)
  File "/var/cnx/venvs/archive/local/lib/python2.7/site-packages/paste/deploy/config.py", line 291, in __call__
    return self.app(environ, start_response)
  File "/var/cnx/venvs/archive/local/lib/python2.7/site-packages/pyramid/router.py", line 270, in __call__
    response = self.execution_policy(environ, self)
  File "/var/cnx/venvs/archive/local/lib/python2.7/site-packages/pyramid/router.py", line 279, in default_execution_policy
    return request.invoke_exception_view(reraise=True)
  File "/var/cnx/venvs/archive/local/lib/python2.7/site-packages/pyramid/view.py", line 778, in invoke_exception_view
    reraise_(*exc_info)
  File "/var/cnx/venvs/archive/local/lib/python2.7/site-packages/pyramid/router.py", line 277, in default_execution_policy
    return router.invoke_request(request)
  File "/var/cnx/venvs/archive/local/lib/python2.7/site-packages/pyramid/router.py", line 249, in invoke_request
    response = handle_request(request)
  File "/var/cnx/venvs/archive/local/lib/python2.7/site-packages/cnxarchive/tweens.py", line 7, in conditional_http_tween
    response = handler(request)
  File "/var/cnx/venvs/archive/local/lib/python2.7/site-packages/pyramid_sawing/main.py", line 39, in __call__
    request.response = self.handler(request)
  File "/var/cnx/venvs/archive/local/lib/python2.7/site-packages/pyramid/tweens.py", line 43, in excview_tween
    response = _error_handler(request, exc)
  File "/var/cnx/venvs/archive/local/lib/python2.7/site-packages/pyramid/tweens.py", line 17, in _error_handler
    reraise(*exc_info)
  File "/var/cnx/venvs/archive/local/lib/python2.7/site-packages/pyramid/tweens.py", line 41, in excview_tween
    response = handler(request)
  File "/var/cnx/venvs/archive/local/lib/python2.7/site-packages/pyramid/router.py", line 148, in handle_request
    registry, request, context, context_iface, view_name
  File "/var/cnx/venvs/archive/local/lib/python2.7/site-packages/pyramid/view.py", line 667, in _call_view
    response = view_callable(context, request)
  File "/var/cnx/venvs/archive/local/lib/python2.7/site-packages/pyramid/config/views.py", line 188, in attr_view
    return view(context, request)
  File "/var/cnx/venvs/archive/local/lib/python2.7/site-packages/pyramid/config/views.py", line 214, in predicate_wrapper
    return view(context, request)
  File "/var/cnx/venvs/archive/local/lib/python2.7/site-packages/pyramid/viewderivers.py", line 275, in wrapper
    response = view(context, request)
  File "/var/cnx/venvs/archive/local/lib/python2.7/site-packages/pyramid/viewderivers.py", line 460, in rendered_view
    request, result, view_inst, context
  File "/var/cnx/venvs/archive/local/lib/python2.7/site-packages/pyramid/renderers.py", line 451, in render_view
    return self.render_to_response(response, system, request=request)
  File "/var/cnx/venvs/archive/local/lib/python2.7/site-packages/pyramid/renderers.py", line 474, in render_to_response
    result = self.render(value, system_values, request=request)
  File "/var/cnx/venvs/archive/local/lib/python2.7/site-packages/pyramid/renderers.py", line 470, in render
    result = renderer(value, system_values)
  File "/var/cnx/venvs/archive/local/lib/python2.7/site-packages/pyramid_jinja2/__init__.py", line 265, in __call__
    return template.render(system)
  File "/var/cnx/venvs/archive/local/lib/python2.7/site-packages/jinja2/environment.py", line 1008, in render
    return self.environment.handle_exception(exc_info, True)
  File "/var/cnx/venvs/archive/local/lib/python2.7/site-packages/jinja2/environment.py", line 780, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/var/cnx/venvs/archive/local/lib/python2.7/site-packages/cnxarchive/views/templates/xpath.html", line 12, in top-level template code
    <a href="{{ result.uri }}">{{ result.title }}</a>
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 2: ordinal not in range(128)
```

When the result contains a page with a non-ascii title, the page fails
and returns "Internal Server Error".