### PR TITLE
Add twine check on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,9 @@ script:
   #- coverage run --source=cnxarchive setup.py test
   - docker-compose -f .travis-compose.yml exec archive /bin/bash -c "cd /src; TESTING_CONFIG=cnxarchive/tests/.travis-testing.ini coverage run --source=cnxarchive setup.py test"
   - docker-compose -f .travis-compose.yml down
+  - pip install twine
+  - python setup.py bdist_wheel
+  - twine check dist/*
 after_success:
   # Report test coverage to codecov.io
   - docker-compose -f .travis-compose.yml exec archive /bin/bash -c "codecov"


### PR DESCRIPTION
To avoid tagging and then getting rejected by pypi, we're running twine
check on travis so it will catch all the errors before we upload to
pypi.