### PR TITLE
adding Requires-Version metadata to setup.py for 2.7 and +3.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ description = "An archive for Connexions documents."
 
 setup(
     name='cnx-archive',
+    python_requires='>=2.7,>=3.5',
     version=versioneer.get_version(),
     author='Connexions team',
     author_email='info@cnx.org',


### PR DESCRIPTION
* As per [PEP345](https://www.python.org/dev/peps/pep-0345/#requires-python) Adding the python version metadata to setup.py.

I hope this fixes the fact that cnx-archive is not in pypi when trying to use python 2.7 pip install command.